### PR TITLE
Bugfix in autoload test.

### DIFF
--- a/Tests/autoload.php.dist
+++ b/Tests/autoload.php.dist
@@ -25,7 +25,7 @@ require_once VENDOR_DIR . '/pheanstalk/pheanstalk_init.php';
 // Some nifty namespaces taking care of (borrowed from FOSUserBundle)
 spl_autoload_register(function($class) {
     if (0 === strpos($class, 'Wowo\\QueueBundle')) {
-        $path = __DIR__.'/../'.implode('/', array_slice(explode('\\', $class), 3)).'.php';
+        $path = __DIR__.'/../'.implode('/', array_slice(explode('\\', $class), 2)).'.php';
         if (!stream_resolve_include_path($path)) {
             return false;
         }


### PR DESCRIPTION
Now the root namespace has only 2 levels (Wowo\QueueBundle).
